### PR TITLE
Fixed Quality Of Life Filter

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export type ModType = "MelonLoader" | "BepInEx" | "Both";
 
 export enum ModCategory {
   Performance = "Performance",
-  QualityOfLife = "QualityOfLife",
+  QualityOfLife = "Quality of Life",
   Content = "Content",
   Overhaul = "Overhaul",
   Other = "Other",


### PR DESCRIPTION
The QualityOfLife enum member value in the ModCategory enum did not match the corresponding JSON value for the category.